### PR TITLE
Refactor `AdwaitaThemeData` into a class

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:adwaita/adwaita.dart' as adwaita;
+import 'package:adwaita/adwaita.dart';
 
 void main() => runApp(MyApp());
 
@@ -14,8 +14,8 @@ class MyApp extends StatelessWidget {
         valueListenable: themeNotifier,
         builder: (_, ThemeMode currentMode, __) {
           return MaterialApp(
-              theme: adwaita.lightTheme,
-              darkTheme: adwaita.darkTheme,
+              theme: AdwaitaThemeData.light(),
+              darkTheme: AdwaitaThemeData.dark(),
               debugShowCheckedModeBanner: false,
               home: MyHomePage(themeNotifier: themeNotifier),
               themeMode: currentMode);

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -72,7 +72,7 @@ class AdwaitaThemeData {
               color: Colors.transparent,
             ),
           ),
-          focusedBorder: OutlineInputBorder(
+          focusedBorder: const OutlineInputBorder(
             borderRadius: BorderRadius.all(
               Radius.circular(8.0),
             ),
@@ -356,7 +356,7 @@ class AdwaitaThemeData {
     fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
   );
 
-  static final _appBarLightTheme = const AppBarTheme(
+  static const _appBarLightTheme = AppBarTheme(
     elevation: 1.0,
     systemOverlayStyle: SystemUiOverlayStyle.light,
     backgroundColor: AdwaitaColors.headerBarBackground,
@@ -365,7 +365,7 @@ class AdwaitaThemeData {
     actionsIconTheme: IconThemeData(color: AdwaitaColors.dark3),
   );
 
-  static final _appBarDarkTheme = const AppBarTheme(
+  static const _appBarDarkTheme = AppBarTheme(
     elevation: 1.0,
     systemOverlayStyle: SystemUiOverlayStyle.dark,
     backgroundColor: AdwaitaColors.darkHeaderBarBackground,

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' show SystemUiOverlayStyle;
 import 'package:adwaita/src/utils/colors.dart';
 
 class AdwaitaThemeData {

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,346 +1,374 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:adwaita/src/utils/colors.dart' as adwaita;
+import 'package:adwaita/src/utils/colors.dart';
 
-final _lightColorScheme = ColorScheme.fromSwatch(
-  // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
-  primarySwatch: adwaita.Colors.primarySwatchColor,
-  primaryColorDark: adwaita.Colors.darkBackgroundColor,
-  accentColor: adwaita.Colors.blueAccent,
-  cardColor: adwaita.Colors.cardBackground,
-  backgroundColor: adwaita.Colors.backgroundColor,
-  errorColor: adwaita.Colors.red,
-  brightness: Brightness.light,
-);
+class AdwaitaThemeData {
+  const AdwaitaThemeData._();
 
-final _darkColorScheme = ColorScheme.fromSwatch(
-  // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
-  primarySwatch: adwaita.Colors.primarySwatchColor,
-  primaryColorDark: adwaita.Colors.darkBackgroundColor,
-  accentColor: adwaita.Colors.blueAccent,
-  cardColor: adwaita.Colors.darkCardBackground,
-  backgroundColor: adwaita.Colors.darkBackgroundColor,
-  errorColor: adwaita.Colors.red,
-  brightness: Brightness.dark,
-);
-
-final lightTheme = ThemeData(
-    tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
+  static final _lightColorScheme = ColorScheme.fromSwatch(
+    // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
+    primarySwatch: AdwaitaColors.primarySwatchColor,
+    primaryColorDark: AdwaitaColors.darkBackgroundColor,
+    accentColor: AdwaitaColors.blueAccent,
+    cardColor: AdwaitaColors.cardBackground,
+    backgroundColor: AdwaitaColors.backgroundColor,
+    errorColor: AdwaitaColors.red,
     brightness: Brightness.light,
-    primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
-    canvasColor: _lightColorScheme.background,
-    scaffoldBackgroundColor: _lightColorScheme.background,
-    bottomAppBarColor: _lightColorScheme.surface,
-    cardColor: _lightColorScheme.surface,
-    dividerColor: _lightColorScheme.onSurface.withOpacity(0.12),
-    backgroundColor: _lightColorScheme.background,
-    dialogBackgroundColor: _lightColorScheme.background,
-    errorColor: _lightColorScheme.error,
-    indicatorColor: _lightColorScheme.secondary,
-    applyElevationOverlayColor: false,
-    colorScheme: _lightColorScheme,
-    buttonTheme: _buttonThemeData,
-    elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.light),
-    outlinedButtonTheme: _outlinedButtonThemeData,
-    textButtonTheme: _textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
-    appBarTheme: _appBarLightTheme,
-    floatingActionButtonTheme: const FloatingActionButtonThemeData(
-      backgroundColor: adwaita.Colors.blueAccent,
-    ),
-    bottomNavigationBarTheme: BottomNavigationBarThemeData(
-      selectedItemColor: _lightColorScheme.primary,
-      unselectedItemColor: adwaita.Colors.dark3,
-    ),
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: adwaita.Colors.button,
-      enabledBorder: const OutlineInputBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(8.0),
-        ),
-        borderSide: BorderSide(
-            width: 1.0, style: BorderStyle.solid, color: Colors.transparent),
-      ),
-      focusedBorder: const OutlineInputBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(8.0),
-        ),
-        borderSide: BorderSide(
-            width: 1.0,
-            style: BorderStyle.solid,
-            color: adwaita.Colors.blueAccent),
-      ),
-    ));
+  );
 
-final darkTheme = ThemeData(
-    tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
-    dialogTheme: DialogTheme(
-        backgroundColor: adwaita.Colors.dark3,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(6),
-            side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  static final _darkColorScheme = ColorScheme.fromSwatch(
+    // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
+    primarySwatch: AdwaitaColors.primarySwatchColor,
+    primaryColorDark: AdwaitaColors.darkBackgroundColor,
+    accentColor: AdwaitaColors.blueAccent,
+    cardColor: AdwaitaColors.darkCardBackground,
+    backgroundColor: AdwaitaColors.darkBackgroundColor,
+    errorColor: AdwaitaColors.red,
     brightness: Brightness.dark,
-    primaryColor: _darkColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
-    canvasColor: _darkColorScheme.background,
-    scaffoldBackgroundColor: _darkColorScheme.background,
-    bottomAppBarColor: _darkColorScheme.surface,
-    cardColor: _darkColorScheme.surface,
-    dividerColor: _darkColorScheme.onSurface.withOpacity(0.12),
-    backgroundColor: _darkColorScheme.background,
-    dialogBackgroundColor: _darkColorScheme.background,
-    errorColor: _darkColorScheme.error,
-    // textTheme: _textTheme,
-    indicatorColor: _darkColorScheme.secondary,
-    applyElevationOverlayColor: true,
-    colorScheme: _darkColorScheme,
-    buttonTheme: _buttonThemeData,
-    textButtonTheme: _darkTextButtonThemeData,
-    elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.dark),
-    outlinedButtonTheme: _darkOutlinedButtonThemeData,
-    switchTheme: _switchStyleDark,
-    checkboxTheme: _checkStyleDark,
-    radioTheme: _radioStyleDark,
-    primaryColorDark: adwaita.Colors.blueAccent,
-    appBarTheme: _appBarDarkTheme,
-    floatingActionButtonTheme: const FloatingActionButtonThemeData(
-      backgroundColor: adwaita.Colors.blueAccent,
-    ),
-    bottomNavigationBarTheme: BottomNavigationBarThemeData(
-      selectedItemColor: _darkColorScheme.primary,
-      unselectedItemColor: adwaita.Colors.warmGrey.shade300,
-    ),
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: adwaita.Colors.darkButton,
-      enabledBorder: const OutlineInputBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(8.0),
+  );
+
+  static ThemeData light() => ThemeData(
+        tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
+        brightness: Brightness.light,
+        primaryColor: _lightColorScheme.primary,
+        primaryColorBrightness:
+            ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
+        canvasColor: _lightColorScheme.background,
+        scaffoldBackgroundColor: _lightColorScheme.background,
+        bottomAppBarColor: _lightColorScheme.surface,
+        cardColor: _lightColorScheme.surface,
+        dividerColor: _lightColorScheme.onSurface.withOpacity(0.12),
+        backgroundColor: _lightColorScheme.background,
+        dialogBackgroundColor: _lightColorScheme.background,
+        errorColor: _lightColorScheme.error,
+        indicatorColor: _lightColorScheme.secondary,
+        applyElevationOverlayColor: false,
+        colorScheme: _lightColorScheme,
+        buttonTheme: _buttonThemeData,
+        elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.light),
+        outlinedButtonTheme: _outlinedButtonThemeData,
+        textButtonTheme: _textButtonThemeData,
+        switchTheme: _switchStyleLight,
+        checkboxTheme: _checkStyleLight,
+        radioTheme: _radioStyleLight,
+        appBarTheme: _appBarLightTheme,
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          backgroundColor: AdwaitaColors.blueAccent,
         ),
-        borderSide: BorderSide(
-            width: 1.0, style: BorderStyle.solid, color: Colors.transparent),
-      ),
-      focusedBorder: const OutlineInputBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(8.0),
+        bottomNavigationBarTheme: BottomNavigationBarThemeData(
+          selectedItemColor: _lightColorScheme.primary,
+          unselectedItemColor: AdwaitaColors.dark3,
         ),
-        borderSide: BorderSide(
-            width: 1.0,
-            style: BorderStyle.solid,
-            color: adwaita.Colors.blueAccent),
-      ),
-    ));
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: AdwaitaColors.button,
+          enabledBorder: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(
+              Radius.circular(8.0),
+            ),
+            borderSide: BorderSide(
+              width: 1.0,
+              style: BorderStyle.solid,
+              color: Colors.transparent,
+            ),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.all(
+              Radius.circular(8.0),
+            ),
+            borderSide: BorderSide(
+              width: 1.0,
+              style: BorderStyle.solid,
+              color: AdwaitaColors.blueAccent,
+            ),
+          ),
+        ),
+      );
+
+  static ThemeData dark() => ThemeData(
+        tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
+        dialogTheme: DialogTheme(
+          backgroundColor: AdwaitaColors.dark3,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(6),
+            side: BorderSide(
+              color: Colors.white.withOpacity(0.2),
+            ),
+          ),
+        ),
+        brightness: Brightness.dark,
+        primaryColor: _darkColorScheme.primary,
+        primaryColorBrightness:
+            ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
+        canvasColor: _darkColorScheme.background,
+        scaffoldBackgroundColor: _darkColorScheme.background,
+        bottomAppBarColor: _darkColorScheme.surface,
+        cardColor: _darkColorScheme.surface,
+        dividerColor: _darkColorScheme.onSurface.withOpacity(0.12),
+        backgroundColor: _darkColorScheme.background,
+        dialogBackgroundColor: _darkColorScheme.background,
+        errorColor: _darkColorScheme.error,
+        // textTheme: _textTheme,
+        indicatorColor: _darkColorScheme.secondary,
+        applyElevationOverlayColor: true,
+        colorScheme: _darkColorScheme,
+        buttonTheme: _buttonThemeData,
+        textButtonTheme: _darkTextButtonThemeData,
+        elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.dark),
+        outlinedButtonTheme: _darkOutlinedButtonThemeData,
+        switchTheme: _switchStyleDark,
+        checkboxTheme: _checkStyleDark,
+        radioTheme: _radioStyleDark,
+        primaryColorDark: AdwaitaColors.blueAccent,
+        appBarTheme: _appBarDarkTheme,
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          backgroundColor: AdwaitaColors.blueAccent,
+        ),
+        bottomNavigationBarTheme: BottomNavigationBarThemeData(
+          selectedItemColor: _darkColorScheme.primary,
+          unselectedItemColor: AdwaitaColors.warmGrey.shade300,
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: AdwaitaColors.darkButton,
+          enabledBorder: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(
+              Radius.circular(8.0),
+            ),
+            borderSide: BorderSide(
+              width: 1.0,
+              style: BorderStyle.solid,
+              color: Colors.transparent,
+            ),
+          ),
+          focusedBorder: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(
+              Radius.circular(8.0),
+            ),
+            borderSide: BorderSide(
+              width: 1.0,
+              style: BorderStyle.solid,
+              color: AdwaitaColors.blueAccent,
+            ),
+          ),
+        ),
+      );
 
 // Special casing some widgets to get the desired Adwaita look
 // Buttons
 
-var _commonButtonStyle = ButtonStyle(
+  static final _commonButtonStyle = ButtonStyle(
     visualDensity: VisualDensity.standard,
-    backgroundColor: MaterialStateProperty.resolveWith<Color>(
-      (Set<MaterialState> states) {
-        if (states.contains(MaterialState.pressed)) {
-          return adwaita.Colors.light4;
-        }
-        return adwaita.Colors.light2; // Use the component's default.
-      },
-    ));
+    backgroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+      if (states.contains(MaterialState.pressed)) {
+        return AdwaitaColors.light4;
+      }
+      return AdwaitaColors.light2; // Use the component's default.
+    }),
+  );
 
-var _darkCommonButtonStyle = ButtonStyle(
+  static final _darkCommonButtonStyle = ButtonStyle(
     visualDensity: VisualDensity.standard,
-    backgroundColor: MaterialStateProperty.resolveWith<Color>(
-      (Set<MaterialState> states) {
-        if (states.contains(MaterialState.pressed)) {
-          return adwaita.Colors.dark5;
-        }
-        return adwaita.Colors.dark2; // Use the component's default.
-      },
-    ));
+    backgroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+      if (states.contains(MaterialState.pressed)) {
+        return AdwaitaColors.dark5;
+      }
+      return AdwaitaColors.dark2; // Use the component's default.
+    }),
+  );
 
-final _buttonThemeData = ButtonThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(4.0),
-  ),
-);
+  static final _buttonThemeData = ButtonThemeData(
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(4.0),
+    ),
+  );
 
-final _outlinedButtonThemeData = OutlinedButtonThemeData(
+  static final _outlinedButtonThemeData = OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
-        visualDensity: _commonButtonStyle.visualDensity,
-        primary: adwaita.Colors.dark4,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(5)),
-        )));
+      visualDensity: _commonButtonStyle.visualDensity,
+      primary: AdwaitaColors.dark4,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(5)),
+      ),
+    ),
+  );
 
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
+  static final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
-        visualDensity: _commonButtonStyle.visualDensity,
-        primary: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: const BorderRadius.all(Radius.circular(20)),
-          side: BorderSide(color: Colors.black.withOpacity(0.75)),
-        )));
+      visualDensity: _commonButtonStyle.visualDensity,
+      primary: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: const BorderRadius.all(Radius.circular(20)),
+        side: BorderSide(color: Colors.black.withOpacity(0.75)),
+      ),
+    ),
+  );
 
-final _textButtonThemeData = TextButtonThemeData(
+  static final _textButtonThemeData = TextButtonThemeData(
     style: TextButton.styleFrom(
-  visualDensity: _commonButtonStyle.visualDensity,
-  backgroundColor: adwaita.Colors.button,
-  primary: adwaita.Colors.dark4,
-  shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(8)),
-      side: BorderSide(color: Colors.transparent)),
-));
+      visualDensity: _commonButtonStyle.visualDensity,
+      backgroundColor: AdwaitaColors.button,
+      primary: AdwaitaColors.dark4,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+        side: BorderSide(color: Colors.transparent),
+      ),
+    ),
+  );
 
-final _darkTextButtonThemeData = TextButtonThemeData(
+  static final _darkTextButtonThemeData = TextButtonThemeData(
     style: TextButton.styleFrom(
-  visualDensity: _darkCommonButtonStyle.visualDensity,
-  backgroundColor: adwaita.Colors.darkButton,
-  primary: Colors.white,
-  shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(8)),
-      side: BorderSide(color: Colors.transparent)),
-));
+      visualDensity: _darkCommonButtonStyle.visualDensity,
+      backgroundColor: AdwaitaColors.darkButton,
+      primary: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+        side: BorderSide(color: Colors.transparent),
+      ),
+    ),
+  );
 
-ElevatedButtonThemeData _getElevatedButtonThemeData(Brightness brightness) {
-  if (brightness == Brightness.light) {
-    return ElevatedButtonThemeData(style: _commonButtonStyle);
+  static ElevatedButtonThemeData _getElevatedButtonThemeData(
+    Brightness brightness,
+  ) {
+    if (brightness == Brightness.light) {
+      return ElevatedButtonThemeData(style: _commonButtonStyle);
+    }
+    return ElevatedButtonThemeData(style: _darkCommonButtonStyle);
   }
-  return ElevatedButtonThemeData(style: _darkCommonButtonStyle);
-}
 
 // Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return adwaita.Colors.dark2;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent;
+  static Color _getSwitchThumbColorDark(Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled)) {
+      return AdwaitaColors.dark2;
     } else {
-      return adwaita.Colors.warmGrey;
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent;
+      } else {
+        return AdwaitaColors.warmGrey;
+      }
     }
   }
-}
 
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return adwaita.Colors.dark2.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent.withAlpha(160);
+  static Color _getSwitchTrackColorDark(Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled)) {
+      return AdwaitaColors.dark2.withAlpha(120);
     } else {
-      return adwaita.Colors.warmGrey.withAlpha(80);
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent.withAlpha(160);
+      } else {
+        return AdwaitaColors.warmGrey.withAlpha(80);
+      }
     }
   }
-}
 
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
+  static final _switchStyleDark = SwitchThemeData(
+    thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
+    trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
+  );
 
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return adwaita.Colors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent;
+  static Color _getSwitchThumbColorLight(Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled)) {
+      return AdwaitaColors.warmGrey.shade200;
     } else {
-      return Colors.white;
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent;
+      } else {
+        return Colors.white;
+      }
     }
   }
-}
 
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return adwaita.Colors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent.withAlpha(180);
+  static Color _getSwitchTrackColorLight(Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled)) {
+      return AdwaitaColors.warmGrey.shade200;
     } else {
-      return adwaita.Colors.warmGrey.shade300;
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent.withAlpha(180);
+      } else {
+        return AdwaitaColors.warmGrey.shade300;
+      }
     }
   }
-}
 
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
+  static final _switchStyleLight = SwitchThemeData(
+    thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
+    trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
+  );
 
 // Checks
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent;
+  static Color _getCheckFillColorDark(Set<MaterialState> states) {
+    if (!states.contains(MaterialState.disabled)) {
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent;
+      }
+      return AdwaitaColors.warmGrey.shade400;
     }
-    return adwaita.Colors.warmGrey.shade400;
+    return AdwaitaColors.warmGrey.withOpacity(0.4);
   }
-  return adwaita.Colors.warmGrey.withOpacity(0.4);
-}
 
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return adwaita.Colors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return adwaita.Colors.blueAccent;
+  static Color _getCheckColorDark(Set<MaterialState> states) {
+    if (!states.contains(MaterialState.disabled)) {
+      return Colors.white;
     }
-    return adwaita.Colors.warmGrey;
+    return AdwaitaColors.warmGrey;
   }
-  return adwaita.Colors.warmGrey.shade300;
-}
 
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
+  static final _checkStyleDark = CheckboxThemeData(
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(2),
+    ),
+    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
+    checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
+  );
+
+  static Color _getCheckFillColorLight(Set<MaterialState> states) {
+    if (!states.contains(MaterialState.disabled)) {
+      if (states.contains(MaterialState.selected)) {
+        return AdwaitaColors.blueAccent;
+      }
+      return AdwaitaColors.warmGrey;
+    }
+    return AdwaitaColors.warmGrey.shade300;
   }
-  return adwaita.Colors.warmGrey;
-}
 
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
+  static Color _getCheckColorLight(Set<MaterialState> states) {
+    if (!states.contains(MaterialState.disabled)) {
+      return Colors.white;
+    }
+    return AdwaitaColors.warmGrey;
+  }
+
+  static final _checkStyleLight = CheckboxThemeData(
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(2),
+    ),
+    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
+    checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
+  );
 
 // Radios
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));
+  static final _radioStyleDark = RadioThemeData(
+    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
+  );
 
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));
+  static final _radioStyleLight = RadioThemeData(
+    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
+  );
 
-var _appBarLightTheme = const AppBarTheme(
-  elevation: 1.0,
-  systemOverlayStyle: SystemUiOverlayStyle.light,
-  backgroundColor: adwaita.Colors.headerBarBackground,
-  foregroundColor: adwaita.Colors.headerBarForeground,
-  iconTheme: IconThemeData(color: adwaita.Colors.dark3),
-  actionsIconTheme: IconThemeData(color: adwaita.Colors.dark3),
-);
+  static final _appBarLightTheme = const AppBarTheme(
+    elevation: 1.0,
+    systemOverlayStyle: SystemUiOverlayStyle.light,
+    backgroundColor: AdwaitaColors.headerBarBackground,
+    foregroundColor: AdwaitaColors.headerBarForeground,
+    iconTheme: IconThemeData(color: AdwaitaColors.dark3),
+    actionsIconTheme: IconThemeData(color: AdwaitaColors.dark3),
+  );
 
-var _appBarDarkTheme = const AppBarTheme(
-  elevation: 1.0,
-  systemOverlayStyle: SystemUiOverlayStyle.dark,
-  backgroundColor: adwaita.Colors.darkHeaderBarBackground,
-  foregroundColor: adwaita.Colors.darkHeaderBarForeground,
-);
+  static final _appBarDarkTheme = const AppBarTheme(
+    elevation: 1.0,
+    systemOverlayStyle: SystemUiOverlayStyle.dark,
+    backgroundColor: AdwaitaColors.darkHeaderBarBackground,
+    foregroundColor: AdwaitaColors.darkHeaderBarForeground,
+  );
+}

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart' show Color, MaterialColor;
 // and https://gitlab.gnome.org/Teams/Design/brand/-/blob/master/brand-book.pdf
 
 /// The Adwaita color palette
-class Colors {
-  Colors._();
+class AdwaitaColors {
+  const AdwaitaColors._();
 
   static const Color blueAccent = Color(0xFF4a86cf);
 


### PR DESCRIPTION
Closes #5.

- Wrap all content from the `theme.dart` file into a const class.
- Rename `Colors` class to `AdwaitaColors` to avoid confusions with other set of colors.
- Make class constructors `const`.